### PR TITLE
Fixed iOs touch behaviour

### DIFF
--- a/src/components/DayCell.js
+++ b/src/components/DayCell.js
@@ -14,6 +14,7 @@ class DayCell extends Component {
     };
     this.getClassNames = this.getClassNames.bind(this);
     this.handleMouseEvent = this.handleMouseEvent.bind(this);
+    this.handleTouchEvent = this.handleTouchEvent.bind(this);
     this.handleKeyEvent = this.handleKeyEvent.bind(this);
     this.renderSelectionPlaceholders = this.renderSelectionPlaceholders.bind(this);
     this.renderPreviewPlaceholder = this.renderPreviewPlaceholder.bind(this);
@@ -33,8 +34,12 @@ class DayCell extends Component {
     }
   }
   handleMouseEvent(event) {
+    if (this.state.useTouch && event.type !== 'mouseleave') return;
     const { day, disabled, onPreviewChange } = this.props;
     const stateChanges = {};
+    if (this.state.useTouch) {
+      stateChanges.useTouch = false;
+    }
     if (disabled) {
       onPreviewChange();
       return;
@@ -63,6 +68,35 @@ class DayCell extends Component {
         onPreviewChange(day);
         break;
     }
+    if (Object.keys(stateChanges).length) {
+      this.setState(stateChanges);
+    }
+  }
+  handleTouchEvent(event) {
+    const { day, disabled, onPreviewChange } = this.props;
+    const stateChanges = {};
+    if (!this.state.useTouch) {
+      stateChanges.useTouch = true;
+    }
+    if (disabled) {
+      onPreviewChange();
+      return;
+    }
+
+    switch (event.type) {
+      case 'touchstart':
+        stateChanges.active = true;
+        break;
+      case 'touchmove':
+        stateChanges.active = false;
+        break;
+      case 'touchend':
+        if (this.state.active) {
+          this.props.onMouseUp(day);
+        }
+        break;
+    }
+
     if (Object.keys(stateChanges).length) {
       this.setState(stateChanges);
     }
@@ -174,6 +208,9 @@ class DayCell extends Component {
         onPauseCapture={this.handleMouseEvent}
         onKeyDown={this.handleKeyEvent}
         onKeyUp={this.handleKeyEvent}
+        onTouchEnd={this.handleTouchEvent}
+        onTouchStart={this.handleTouchEvent}
+        onTouchMove={this.handleTouchEvent}
         className={this.getClassNames(styles)}
         {...(this.props.disabled || this.props.isPassive ? { tabIndex: -1 } : {})}
         style={{ color: this.props.color }}>


### PR DESCRIPTION
Brings iOs touch behaviour in line with other devices.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
Due to iOs Safari emulating hover states via firing a mouseenter event on first touch, the user has to touch twice to select a date.

This fixes said behaviour and allows for a single click selection. As this required a user flag to disable mouse events completely on touch interaction ( due to IOs scrolling behaviour ), tests have been made to secure hot swap between mouse and touch input on the same device still works.

Behaviour for date range selection tested on:
- Mobile Devices:
  - IPhone 4 ( Safari )
  - Nokia 3.1, Android 8.1 ( Chrome )
- Desktop
  - Debian 9, Chrome
  - Debian 9, Firefox
- Emulator
  - Nexus 5, API 27 ( Chrome )
  - Nexus 7, API 27 ( Chrome ), both with attached mouse and touch


> Related Issue: #241 