### PR TITLE
feat: InputDateRange label as a Component

### DIFF
--- a/src/components/InputRangeField/index.js
+++ b/src/components/InputRangeField/index.js
@@ -51,7 +51,7 @@ class InputRangeField extends Component {
 
 InputRangeField.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  label: PropTypes.string.isRequired,
+  label:  PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired,
   placeholder: PropTypes.string,
   styles: PropTypes.shape({
     inputRange: PropTypes.string,

--- a/src/components/InputRangeField/index.js
+++ b/src/components/InputRangeField/index.js
@@ -51,7 +51,7 @@ class InputRangeField extends Component {
 
 InputRangeField.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  label:  PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired,
+  label: PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired,
   placeholder: PropTypes.string,
   styles: PropTypes.shape({
     inputRange: PropTypes.string,

--- a/src/components/InputRangeField/index.test.js
+++ b/src/components/InputRangeField/index.test.js
@@ -72,4 +72,40 @@ describe('InputRangeField tests', () => {
     expect(wrapper.find(`.${styles.inputRangeInput}`).prop('placeholder')).toEqual('-');
     expect(wrapper.find(`.${styles.inputRangeLabel}`).text()).toEqual('Label');
   });
+
+  test('Should render the label as a Component', () => {
+    const Label = () => <span className="input-range-field-label">Input label</span>;
+    const wrapper = mount(
+      <InputRangeField
+        value={12}
+        placeholder="Placeholder"
+        label={<Label />}
+        styles={styles}
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+      />
+    );
+
+    expect(wrapper.find(`.${styles.inputRangeInput}`).prop('value')).toEqual(12);
+    expect(wrapper.find(`.${styles.inputRangeInput}`).prop('placeholder')).toEqual('Placeholder');
+    expect(wrapper.find(`.${styles.inputRangeLabel}`).text()).toEqual('Input label');
+    expect(wrapper.find(`.${styles.inputRangeLabel}`).text()).toEqual('Input label');
+    expect(wrapper.find(`.input-range-field-label`).text()).toEqual('Input label');
+
+    wrapper.setProps({ value: '32' });
+    expect(wrapper.find(`.${styles.inputRangeInput}`).prop('value')).toEqual('32');
+    expect(wrapper.find(`.${styles.inputRangeInput}`).prop('placeholder')).toEqual('Placeholder');
+    expect(wrapper.find(`.${styles.inputRangeLabel}`).text()).toEqual('Input label');
+
+    wrapper.setProps({ placeholder: '-' });
+    expect(wrapper.find(`.${styles.inputRangeInput}`).prop('value')).toEqual('32');
+    expect(wrapper.find(`.${styles.inputRangeInput}`).prop('placeholder')).toEqual('-');
+    expect(wrapper.find(`.${styles.inputRangeLabel}`).text()).toEqual('Input label');
+
+    wrapper.setProps({ label: 'Label' });
+    expect(wrapper.find(`.${styles.inputRangeInput}`).prop('value')).toEqual('32');
+    expect(wrapper.find(`.${styles.inputRangeInput}`).prop('placeholder')).toEqual('-');
+    expect(wrapper.find(`.${styles.inputRangeLabel}`).text()).toEqual('Label');
+  });
 });


### PR DESCRIPTION
Added the possibility to add the `label` prop as a Component

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description

In order to have the possibility to use a *Component* as the label of `InputRangeField`, I'm proposing this change:

```JS
PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired,
```
So that you can use something like this: 

```
const defaultInputRanges = [
  {
    label: <MyFancyReactComponent />,
    ...
  }
]
```

thank you :+1: 

