### PR TITLE
Fix wrong daterange on hover bug

### DIFF
--- a/src/components/DateRangePicker/index.js
+++ b/src/components/DateRangePicker/index.js
@@ -20,7 +20,11 @@ class DateRangePicker extends Component {
       <div className={classnames(this.styles.dateRangePickerWrapper, this.props.className)}>
         <DefinedRange
           focusedRange={focusedRange}
-          onPreviewChange={value => this.dateRange.updatePreview(value)}
+          onPreviewChange={value =>
+            this.dateRange.updatePreview(
+              value ? this.dateRange.calcNewSelection(value, typeof value === 'string') : null
+            )
+          }
           {...this.props}
           range={this.props.ranges[focusedRange[0]]}
           className={undefined}


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
Fixed wrong daterange on hover bug by processing value through `calcNewSelection` before feeding into `updatePreview`. Used `typeof value === "string"` to determine whether the `isSingleValue`.  

> Related Issue: #368