### PR TITLE
Fix bug of calendar not moving to previous months when selecting a preset range of 90 days and the currentFocusedDate is in the right side of the calendar.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,7 @@ import {
   startOfWeek,
   endOfWeek,
   differenceInCalendarDays,
+  differenceInCalendarMonths,
   addDays,
 } from 'date-fns';
 
@@ -35,11 +36,7 @@ export function calcFocusDate(currentFocusedDate, props) {
 
   // // just return targetDate for native scrolled calendars
   // if (props.scroll.enabled) return targetDate;
-  const currentFocusInterval = {
-    start: startOfMonth(currentFocusedDate),
-    end: endOfMonth(addMonths(currentFocusedDate, months - 1)),
-  };
-  if (areIntervalsOverlapping(targetInterval, currentFocusInterval)) {
+  if (differenceInCalendarMonths(targetInterval.start, targetInterval.end) > months) {
     // don't change focused if new selection in view area
     return currentFocusedDate;
   }


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description

Fix bug of calendar not moving to previous months when selecting a preset range of 90 days and the currentFocusedDate is in the right side of the calendar.

> Related Issue: #397 