### PR TITLE
Use babel-plugin-date-fns to reduce bundle size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,8 @@
   ],
   "plugins": [
     ["@babel/plugin-proposal-class-properties"],
-    ["@babel/plugin-proposal-export-default-from"]
+    ["@babel/plugin-proposal-export-default-from"],
+    "date-fns"
   ]
 }
  

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 lib/
 NOTES.txt
 styleguide/
+dist/

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "autoprefixer": "^9.7.3",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
+    "babel-plugin-date-fns": "^2.0.0",
     "css-loader": "^3.2.0",
     "date-fns": "^2.8.1",
     "enzyme": "^3.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1696,6 +1696,11 @@ babel-loader@^8.0.6:
     mkdirp "^0.5.1"
     pify "^4.0.1"
 
+babel-plugin-date-fns@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-date-fns/-/babel-plugin-date-fns-2.0.0.tgz#56074f1b4659c3b1208b5d156d4f51612d7af620"
+  integrity sha512-MbsQzEgglAIBZLQbKQDgMUgFDwf7sSHXgaWRXowiEVs1B+eiBge4JnhBQtIaHIVLE9QmXfDQbb18oggvP7KSFQ==
+
 babel-plugin-dynamic-import-node@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"


### PR DESCRIPTION
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
Reduces number of bundled date-fns functions to only the ones actually used, in the below case the size dropped by 10kb gzipped

![image](https://user-images.githubusercontent.com/969938/98741526-6f91c480-2372-11eb-85ef-7542bca1897e.png)



> Related Issue: #356 