### PR TITLE
Day Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "react-date-range",
-  "version": "1.1.3",
+  "name": "react-date-range-sisu",
+  "version": "1.1.5",
   "description": "A React component for choosing dates and date ranges.",
   "main": "dist/index.js",
   "scripts": {
     "start": "yarn build:css & styleguidist server",
+    "prepare": "yarn build",
     "build": "yarn build:css & yarn build:js & styleguidist build",
     "build:css": "postcss 'src/styles.scss' -d dist --ext css & postcss 'src/theme/*.scss' -d 'dist/theme' --ext css",
     "build:js": "babel ./src --out-dir ./dist --ignore test.js",

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -393,6 +393,7 @@ class Calendar extends PureComponent {
 
     const ranges = this.props.ranges.map((range, i) => ({
       ...range,
+      index: i,
       color: range.color || rangeColors[i] || color,
     }));
     return (

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -133,6 +133,7 @@ DateRange.defaultProps = {
   moveRangeOnFirstSelection: false,
   rangeColors: ['#3d91ff', '#3ecf8e', '#fed14c'],
   disabledDates: [],
+  DayComponent: null,
 };
 
 DateRange.propTypes = {
@@ -142,6 +143,7 @@ DateRange.propTypes = {
   className: PropTypes.string,
   ranges: PropTypes.arrayOf(rangeShape),
   moveRangeOnFirstSelection: PropTypes.bool,
+  DayComponent: PropTypes.func,
 };
 
 export default DateRange;

--- a/src/components/Month/index.js
+++ b/src/components/Month/index.js
@@ -113,7 +113,9 @@ class Month extends PureComponent {
   }
 }
 
-Month.defaultProps = {};
+Month.defaultProps = {
+  DayComponent: null,
+};
 
 Month.propTypes = {
   style: PropTypes.object,
@@ -143,6 +145,7 @@ Month.propTypes = {
   showWeekDays: PropTypes.bool,
   showMonthName: PropTypes.bool,
   fixedHeight: PropTypes.bool,
+  DayComponent: PropTypes.func,
 };
 
 export default Month;

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,10 @@ import {
   differenceInCalendarDays,
   differenceInCalendarMonths,
   addDays,
+  addMonths,
+  isAfter,
+  isBefore,
+  isSameDay
 } from 'date-fns';
 
 export function calcFocusDate(currentFocusedDate, props) {
@@ -38,6 +42,18 @@ export function calcFocusDate(currentFocusedDate, props) {
     // don't change focused if new selection in view area
     return currentFocusedDate;
   }
+
+  const firstShownDate = startOfMonth(currentFocusedDate)
+  const lastShownDate = endOfMonth(addMonths(currentFocusedDate, props.months - 1))
+
+  // if we are still in view of target date, don't shift calendar
+  if (
+    (isSameDay(targetInterval.start, firstShownDate) || isAfter(targetInterval.start, firstShownDate)) &&
+    (isSameDay(targetInterval.end, lastShownDate) || isBefore(targetInterval.end, lastShownDate))
+  ) {
+    return currentFocusedDate;
+  }
+
   return targetDate;
 }
 


### PR DESCRIPTION
1.  Can specify a day component to be used instead of the default component.
2.  Will not shift the months if the currently edited month is already in view.   Previously if the current edited date was in the 2nd month, the calendar would auto-shift to make it first.
3.  Adds index to range values to be used in day components.