### PR TITLE
New Feature: Add time support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 lib/
 NOTES.txt
 styleguide/
+dist/

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ showPreview(DateRange)               | bool      | true             | visibility
 editableDateInputs(Calendar)         | bool      | false            | whether dates can be edited in the Calendar's input fields
 dragSelectionEnabled(Calendar)       | bool      | true             | whether dates can be selected via drag n drop
 onPreviewChange(DateRange)           | Object    |                  | Callback function for preview changes
+showTimePicker                       | Boolean   | false            | Show a time picker when focusing on DateInputs. When set to `true`, `dateDisplayFormat` must include time formatting (e.g. `MMM d, yyyy h:mma`).
 dateDisplayFormat                    | String    | `MMM d, yyyy`    | selected range preview formatter. Check out [date-fns's format option](https://date-fns.org/docs/format)
 dayDisplayFormat                     | String    | `d`              | selected range preview formatter. Check out [date-fns's format option](https://date-fns.org/docs/format)
 weekdayDisplayFormat                 | String    | `E`              | selected range preview formatter. Check out [date-fns's format option](https://date-fns.org/docs/format)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "shallow-equal": "^1.2.1"
   },
   "peerDependencies": {
-    "date-fns": "2.0.0-alpha.7 || >=2.0.0",
+    "date-fns": "^2.20.0",
     "react": "^0.14 || ^15.0.0-rc || >=15.0"
   },
   "devDependencies": {
@@ -57,7 +57,7 @@
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
     "css-loader": "^3.2.0",
-    "date-fns": "^2.8.1",
+    "date-fns": "^2.20.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "enzyme-to-json": "^3.4.3",

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -262,6 +262,7 @@ class Calendar extends PureComponent {
       editableDateInputs,
       startDatePlaceholder,
       endDatePlaceholder,
+      showTimePicker,
     } = this.props;
 
     const defaultColor = rangeColors[focusedRange[0]] || color;
@@ -289,6 +290,7 @@ class Calendar extends PureComponent {
                 dateDisplayFormat={dateDisplayFormat}
                 onChange={this.onDragSelectionEnd}
                 onFocus={() => this.handleRangeFocusChange(i, 0)}
+                showTimePicker={showTimePicker}
               />
               <DateInput
                 className={classnames(styles.dateDisplayItem, {
@@ -302,6 +304,7 @@ class Calendar extends PureComponent {
                 dateDisplayFormat={dateDisplayFormat}
                 onChange={this.onDragSelectionEnd}
                 onFocus={() => this.handleRangeFocusChange(i, 1)}
+                showTimePicker={showTimePicker}
               />
             </div>
           );
@@ -501,6 +504,7 @@ class Calendar extends PureComponent {
 Calendar.defaultProps = {
   showMonthArrow: true,
   showMonthAndYearPickers: true,
+  showTimePicker: false,
   disabledDates: [],
   disabledDay: () => {},
   classNames: {},
@@ -533,6 +537,7 @@ Calendar.defaultProps = {
 Calendar.propTypes = {
   showMonthArrow: PropTypes.bool,
   showMonthAndYearPickers: PropTypes.bool,
+  showTimePicker: PropTypes.bool,
   disabledDates: PropTypes.array,
   disabledDay: PropTypes.func,
   minDate: PropTypes.object,

--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -122,7 +122,7 @@ DateInput.propTypes = {
 DateInput.defaultProps = {
   readOnly: true,
   disabled: false,
-  dateDisplayFormat: 'MMM D, YYYY',
+  dateDisplayFormat: 'MMM d, yyyy',
 };
 
 export default DateInput;

--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -17,6 +17,14 @@ class DateInput extends PureComponent {
     };
   }
 
+  componentDidMount() {
+    if (this.props.showTimePicker && !dateFormatContainsTime(this.props.dateDisplayFormat)) {
+      console.warn(
+        'The `dateDisplayFormat` prop should contain time formatting when the `showTimePicker` prop is set to true. See the date-fns format table: https://date-fns.org/docs/format'
+      );
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { value, showTimePicker, dateDisplayFormat } = prevProps;
 

--- a/src/components/DateInput/index.test.js
+++ b/src/components/DateInput/index.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import DateInput from '../DateInput';
+import TimePicker from '../TimePicker';
+import { mount } from 'enzyme';
+
+describe('DateInput', () => {
+  test('Should resolve', () => {
+    expect(DateInput).toEqual(expect.anything());
+  });
+
+  test('Should warn when TimePicker is used without time formatting', () => {
+    const warn = console.warn;
+    console.warn = jest.fn();
+    const onFocus = jest.fn();
+    const onChange = jest.fn();
+
+    mount(<DateInput showTimePicker onFocus={onFocus} onChange={onChange} />);
+
+    expect(console.warn).toHaveBeenCalled();
+
+    console.warn = warn;
+  });
+
+  test('Should display TimePicker on focus', () => {
+    const onFocus = jest.fn();
+    const onChange = jest.fn();
+
+    const dateInput = mount(
+      <DateInput
+        showTimePicker
+        onFocus={onFocus}
+        onChange={onChange}
+        dateDisplayFormat="MMM d, yyyy h:mma"
+      />
+    );
+
+    dateInput.find('input').simulate('focus');
+
+    expect(dateInput.find(TimePicker)).toHaveLength(1);
+  });
+
+  test('Should not display TimePicker on focus by default', () => {
+    const onFocus = jest.fn();
+    const onChange = jest.fn();
+
+    const dateInput = mount(<DateInput onFocus={onFocus} onChange={onChange} />);
+
+    dateInput.find('input').simulate('focus');
+
+    expect(dateInput.find(TimePicker)).toHaveLength(0);
+  });
+});

--- a/src/components/TimePicker/index.js
+++ b/src/components/TimePicker/index.js
@@ -105,7 +105,7 @@ TimePicker.propTypes = {
 TimePicker.defaultProps = {
   readOnly: true,
   disabled: false,
-  dateDisplayFormat: 'MMM D, YYYY',
+  dateDisplayFormat: 'MMM d, yyyy h:mma',
 };
 
 export default TimePicker;

--- a/src/components/TimePicker/index.js
+++ b/src/components/TimePicker/index.js
@@ -1,0 +1,111 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {
+  isEqual,
+  isValid,
+  eachMinuteOfInterval,
+  differenceInMilliseconds,
+  startOfDay,
+  endOfDay,
+  format,
+  parse,
+} from 'date-fns';
+
+class TimePicker extends PureComponent {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      changes: false,
+      value: this.formatDate(props),
+    };
+
+    this.closest_interval = React.createRef();
+  }
+
+  componentDidMount() {
+    this.closest_interval.current.scrollIntoView();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { value } = prevProps;
+
+    if (!isEqual(value, this.props.value)) {
+      this.setState({ value: this.formatDate(this.props) });
+    }
+  }
+
+  formatDate({ value, dateDisplayFormat, dateOptions }) {
+    if (value && isValid(value)) {
+      return format(value, dateDisplayFormat, dateOptions);
+    }
+    return '';
+  }
+
+  update(value) {
+    const { onChange } = this.props;
+
+    onChange(value);
+  }
+
+  render() {
+    const { value } = this.state;
+
+    const { dateDisplayFormat, dateOptions } = this.props;
+    const parsed = parse(value, dateDisplayFormat, new Date(), dateOptions);
+
+    const intervals = eachMinuteOfInterval(
+      {
+        start: startOfDay(parsed),
+        end: endOfDay(parsed),
+      },
+      { step: 15 }
+    );
+
+    let closest_interval = intervals[0];
+    intervals.forEach(interval => {
+      if (
+        Math.abs(differenceInMilliseconds(parsed, interval)) <
+        Math.abs(differenceInMilliseconds(parsed, closest_interval))
+      ) {
+        closest_interval = interval;
+      }
+    });
+
+    return (
+      <div className={classnames('rdrTimePicker')}>
+        {intervals.map((minute, i) => (
+          <button
+            ref={minute === closest_interval ? this.closest_interval : null}
+            className={minute === closest_interval ? 'active' : ''}
+            key={i}
+            onClick={() => this.update(minute)}
+            type="button">
+            {format(minute, 'h:mma')}
+          </button>
+        ))}
+      </div>
+    );
+  }
+}
+
+TimePicker.propTypes = {
+  value: PropTypes.object,
+  placeholder: PropTypes.string,
+  disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
+  dateOptions: PropTypes.object,
+  dateDisplayFormat: PropTypes.string,
+  className: PropTypes.string,
+  onFocus: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+TimePicker.defaultProps = {
+  readOnly: true,
+  disabled: false,
+  dateDisplayFormat: 'MMM D, YYYY',
+};
+
+export default TimePicker;

--- a/src/components/TimePicker/index.js
+++ b/src/components/TimePicker/index.js
@@ -25,7 +25,9 @@ class TimePicker extends PureComponent {
   }
 
   componentDidMount() {
-    this.closest_interval.current.scrollIntoView();
+    if (this.closest_interval.current) {
+      this.closest_interval.current.scrollIntoView();
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -81,7 +83,8 @@ class TimePicker extends PureComponent {
             className={minute === closest_interval ? 'active' : ''}
             key={i}
             onClick={() => this.update(minute)}
-            type="button">
+            type="button"
+            value={format(minute, 'T')}>
             {format(minute, 'h:mma')}
           </button>
         ))}
@@ -98,7 +101,6 @@ TimePicker.propTypes = {
   dateOptions: PropTypes.object,
   dateDisplayFormat: PropTypes.string,
   className: PropTypes.string,
-  onFocus: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
 };
 

--- a/src/components/TimePicker/index.scss
+++ b/src/components/TimePicker/index.scss
@@ -1,0 +1,22 @@
+.rdrTimePicker {
+	max-height: 200px;
+    overflow-y: scroll;
+    position: absolute;
+    background: #fff;
+    z-index: 1;
+    box-shadow: 0 4px 5px 0 rgb(0 0 0 / 14%), 0 1px 10px 0 rgb(0 0 0 / 12%), 0 2px 4px -1px rgb(0 0 0 / 20%);
+
+	button {
+		min-width: 150px;
+	    padding: 0 15px;
+	    line-height: 40px;
+
+	    &.active {
+	    	background-color: #f1f3f4;
+	    }
+
+	    &:hover {
+    		background-color: #e8eaeb;
+	    }
+	}
+}

--- a/src/components/TimePicker/index.test.js
+++ b/src/components/TimePicker/index.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import TimePicker from '../TimePicker';
+import { mount } from 'enzyme';
+import { differenceInMinutes, parse, eachMinuteOfInterval, startOfDay, endOfDay } from 'date-fns';
+
+describe('TimePicker', () => {
+  test('Should resolve', () => {
+    expect(TimePicker).toEqual(expect.anything());
+  });
+
+  test('Should render buttons for every 15 minutes', () => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+    const onChange = jest.fn();
+    const timePicker = mount(<TimePicker onChange={onChange} value={new Date()} />);
+
+    expect(timePicker.find('button')).toHaveLength(96);
+  });
+
+  test('Should call onChange on button click', () => {
+    const onChange = jest.fn();
+    const timePicker = mount(<TimePicker onChange={onChange} value={new Date()} />);
+
+    timePicker.find('button').forEach(button => button.simulate('click'));
+
+    expect(onChange).toHaveBeenCalledTimes(96);
+  });
+
+  test('Should find closest interval', () => {
+    const onChange = jest.fn();
+
+    const start = startOfDay(new Date());
+    const end = endOfDay(start);
+
+    eachMinuteOfInterval(
+      {
+        start,
+        end,
+      },
+      { step: 4 } // Full coverage would be every 1 minute, but 4 is much faster and covers most cases
+    ).forEach(interval => {
+      const timePicker = mount(<TimePicker onChange={onChange} value={interval} />);
+
+      const closest_interval = parse(
+        timePicker.instance().closest_interval.current.value,
+        'T',
+        new Date()
+      );
+
+      expect(Math.abs(differenceInMinutes(closest_interval, interval))).toBeLessThan(
+        differenceInMinutes(end, interval) > 15 ? 8 : 15
+      );
+    });
+  });
+});

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,3 +4,4 @@
 @import 'components/DayCell/index.scss';
 @import 'components/DateRangePicker/index.scss';
 @import 'components/DefinedRange/index.scss';
+@import 'components/TimePicker/index.scss';

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,12 @@ import {
   differenceInCalendarDays,
   differenceInCalendarMonths,
   addDays,
+  getHours,
+  getMinutes,
+  getSeconds,
+  setHours,
+  setMinutes,
+  setSeconds,
 } from 'date-fns';
 
 export function calcFocusDate(currentFocusedDate, props) {
@@ -63,6 +69,18 @@ export function getMonthDisplayRange(date, dateOptions, fixedHeight) {
     startDateOfMonth,
     endDateOfMonth,
   };
+}
+
+export function getTime(date) {
+  return {
+    hours: getHours(date),
+    minutes: getMinutes(date),
+    seconds: getSeconds(date),
+  };
+}
+
+export function setTime(date, { hours, minutes, seconds }) {
+  return setHours(setMinutes(setSeconds(date, seconds), minutes), hours)
 }
 
 export function generateStyles(sources) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,17 @@ export function getTime(date) {
 }
 
 export function setTime(date, { hours, minutes, seconds }) {
-  return setHours(setMinutes(setSeconds(date, seconds), minutes), hours)
+  return setHours(setMinutes(setSeconds(date, seconds), minutes), hours);
+}
+
+export function dateFormatContainsTime(date_format) {
+  /* eslint-disable prettier/prettier */
+  return [
+    'h', 'ho', 'hh', 'H', 'Ho', 'HH', 'K', 'Ko', 'KK', 'k', 'ko', 'kk',
+    'm', 'mo', 'mm',
+    'p','pp', 'ppp', 'pppp', 'Pp', 'PPpp', 'PPPppp', 'PPPPpppp',
+  ].some(format => date_format.includes(format));
+  /* eslint-enable */
 }
 
 export function generateStyles(sources) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,10 +2755,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.8.1.tgz#2109362ccb6c87c3ca011e9e31f702bc09e4123b"
-  integrity sha512-EL/C8IHvYRwAHYgFRse4MGAPSqlJVlOrhVYZ75iQBKrnv+ZedmYsgwH3t+BCDuZDXpoo07+q9j4qgSSOa7irJg==
+date-fns@^2.20.0:
+  version "2.21.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.21.3.tgz#8f5f6889d7a96bbcc1f0ea50239b397a83357f9b"
+  integrity sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
Add support for selecting times as well as dates. The addition of times is completely optional and disabled by default, this pull request should have no effect on current behaviors unless the `showTimePicker` prop is passed.

When `showTimePicker` is set to true, clicking on either `DateInput` component will show a dropdown of times in 15-minute increments. If `editableDateInputs` is true, then more specific times can be set by typing them directly. It's important that when `showTimePicker` is true that the `dateDisplayFormat` includes `date-fn` time formatting options. (e.g. `MMM d, yyyy h:mma`). If a time format isn't included a console warning will be made.

This also comes with a handful of tests to test basic operation but it is not full coverage.

> Related Issue: #195, #4, and possibly #37.