### PR TITLE
Update range selection behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ scroll                               | Object    | { enabled: false }| infinite 
 showMonthArrow                       | Boolean   | true             | show/hide month arrow button
 navigatorRenderer                    | Func      |                  | renderer for focused date navigation area. fn(currentFocusedDate: Date, changeShownDate: func, props: object)
 ranges                               | *Object[] | []               | Defines ranges. array of range object
-moveRangeOnFirstSelection(DateRange) | Boolean   | false            | move range on startDate selection. Otherwise endDate will replace with startDate.
+moveRangeOnFirstSelection(DateRange) | Boolean   | false            | move range on startDate selection. Otherwise endDate will replace with startDate unless `retainEndDateOnFirstSelection` is set to true.
+retainEndDateOnFirstSelection(DateRange) | Boolean   | false            | Retain end date when the start date is changed, unless start date is later than end date. Ignored if `moveRangeOnFirstSelection` is set to true.
 onChange(Calendar)                   | Func      |                  | callback function for date changes. fn(date: Date)
 onChange(DateRange)                  | Func      |                  | callback function for range changes. fn(changes). changes contains changed ranges with new `startDate`/`endDate` properties.
 color(Calendar)                      | String    | `#3d91ff`        | defines color for selected date in Calendar

--- a/src/components/DateRange/README.md
+++ b/src/components/DateRange/README.md
@@ -3,9 +3,10 @@ This component extends all the props of **[Calendar](#calendar)** component. In 
 | Prop Name  |  Type |
 |---|---|
 |  **moveRangeOnFirstSelection** |  boolean |
-|   **onRangeFocusChange** |  function |
-|   **rangeColors**  |  array |
-|   **ranges**  |  array |
+|  **retainEndDateOnFirstSelection** |  boolean |
+|  **onRangeFocusChange** |  function |
+|  **rangeColors**  |  array |
+|  **ranges**  |  array |
 
 
 #### Example: Editable Date Inputs

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -24,7 +24,6 @@ class DateRange extends Component {
     if (!selectedRange || !onChange) return {};
 
     let { startDate, endDate } = selectedRange;
-    if (!endDate) endDate = new Date(startDate);
     let nextFocusRange;
     if (!isSingleValue) {
       startDate = value.startDate;
@@ -35,6 +34,10 @@ class DateRange extends Component {
       const calculateEndDate = () => {
         if (moveRangeOnFirstSelection) {
           return addDays(value, dayOffset);
+        }
+        // allow continous range to stay as-is
+        if (!endDate) {
+          return endDate;
         }
         return !isBefore(value, endDate) ? value : endDate;
       };

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -32,8 +32,14 @@ class DateRange extends Component {
     } else if (focusedRange[1] === 0) {
       // startDate selection
       const dayOffset = differenceInCalendarDays(endDate, startDate);
+      const calculateEndDate = () => {
+        if (moveRangeOnFirstSelection) {
+          return addDays(value, dayOffset);
+        }
+        return !isBefore(value, endDate) ? value : endDate;
+      };
       startDate = value;
-      endDate = moveRangeOnFirstSelection ? addDays(value, dayOffset) : value;
+      endDate = calculateEndDate();
       if (maxDate) endDate = min([endDate, maxDate]);
       nextFocusRange = [focusedRange[0], 1];
     } else {

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -43,11 +43,10 @@ class DateRange extends Component {
           return addDays(value, dayOffset);
         }
         if (retainEndDateOnFirstSelection) {
-          // allow the unset end date to stay as-is
-          if (!endDate) {
+          if (!endDate || isBefore(value, endDate)) {
             return endDate;
           }
-          return !isBefore(value, endDate) ? value : endDate;
+          return value;
         }
         return value || now;
       };

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -18,28 +18,38 @@ class DateRange extends Component {
   }
   calcNewSelection = (value, isSingleValue = true) => {
     const focusedRange = this.props.focusedRange || this.state.focusedRange;
-    const { ranges, onChange, maxDate, moveRangeOnFirstSelection, disabledDates } = this.props;
+    const {
+      ranges,
+      onChange,
+      maxDate,
+      moveRangeOnFirstSelection,
+      retainEndDateOnFirstSelection,
+      disabledDates,
+    } = this.props;
     const focusedRangeIndex = focusedRange[0];
     const selectedRange = ranges[focusedRangeIndex];
     if (!selectedRange || !onChange) return {};
-
     let { startDate, endDate } = selectedRange;
+    const now = new Date();
     let nextFocusRange;
     if (!isSingleValue) {
       startDate = value.startDate;
       endDate = value.endDate;
     } else if (focusedRange[1] === 0) {
       // startDate selection
-      const dayOffset = differenceInCalendarDays(endDate, startDate);
+      const dayOffset = differenceInCalendarDays(endDate || now, startDate);
       const calculateEndDate = () => {
         if (moveRangeOnFirstSelection) {
           return addDays(value, dayOffset);
         }
-        // allow continous range to stay as-is
-        if (!endDate) {
-          return endDate;
+        if (retainEndDateOnFirstSelection) {
+          // allow the unset end date to stay as-is
+          if (!endDate) {
+            return endDate;
+          }
+          return !isBefore(value, endDate) ? value : endDate;
         }
-        return !isBefore(value, endDate) ? value : endDate;
+        return value || now;
       };
       startDate = value;
       endDate = calculateEndDate();
@@ -140,6 +150,7 @@ DateRange.defaultProps = {
   classNames: {},
   ranges: [],
   moveRangeOnFirstSelection: false,
+  retainEndDateOnFirstSelection: false,
   rangeColors: ['#3d91ff', '#3ecf8e', '#fed14c'],
   disabledDates: [],
 };
@@ -151,6 +162,7 @@ DateRange.propTypes = {
   className: PropTypes.string,
   ranges: PropTypes.arrayOf(rangeShape),
   moveRangeOnFirstSelection: PropTypes.bool,
+  retainEndDateOnFirstSelection: PropTypes.bool,
 };
 
 export default DateRange;

--- a/src/components/DateRange/index.test.js
+++ b/src/components/DateRange/index.test.js
@@ -1,7 +1,57 @@
+import React from 'react';
+import { subDays, addDays, isSameDay } from 'date-fns';
 import DateRange from '../DateRange';
+import renderer from 'react-test-renderer';
+
+let testRenderer = null;
+const endDate = new Date();
+const startDate = subDays(endDate, 7);
+
+const commonProps = {
+  ranges: [{ startDate, endDate, key: 'selection' }],
+  onChange: () => {},
+  moveRangeOnFirstSelection: false,
+};
+
+const compareRanges = (newRange, assertionRange) => {
+  expect(isSameDay(newRange.startDate, assertionRange.startDate)).toEqual(true);
+  expect(isSameDay(newRange.endDate, assertionRange.endDate)).toEqual(true);
+};
+
+beforeEach(() => {
+  testRenderer = renderer.create(<DateRange {...commonProps} />);
+});
 
 describe('DateRange', () => {
   test('Should resolve', () => {
     expect(DateRange).toEqual(expect.anything());
+  });
+
+  test('calculate new selection without moving end date', () => {
+    const instance = testRenderer.getInstance();
+    const methodResult = instance.calcNewSelection(subDays(endDate, 10), true);
+    compareRanges(methodResult.range, {
+      startDate: subDays(endDate, 10),
+      endDate,
+    });
+  });
+
+  test('calculate new selection by resetting end date if start date is not before', () => {
+    const instance = testRenderer.getInstance();
+    const methodResult = instance.calcNewSelection(addDays(endDate, 2), true);
+    compareRanges(methodResult.range, {
+      startDate: addDays(endDate, 2),
+      endDate: addDays(endDate, 2),
+    });
+  });
+
+  test('calculate new selection based on moveRangeOnFirstSelection prop', () => {
+    testRenderer.update(<DateRange {...commonProps} moveRangeOnFirstSelection />);
+    const instance = testRenderer.getInstance();
+    const methodResult = instance.calcNewSelection(subDays(endDate, 10), true);
+    compareRanges(methodResult.range, {
+      startDate: subDays(endDate, 10),
+      endDate: subDays(endDate, 3),
+    });
   });
 });

--- a/src/components/DateRange/index.test.js
+++ b/src/components/DateRange/index.test.js
@@ -20,7 +20,7 @@ const compareRanges = (newRange, assertionRange) => {
       return expect(newRange[key]).toEqual(assertionRange[key]);
     }
     return expect(isSameDay(newRange[key], assertionRange[key])).toEqual(true);
-  })
+  });
 };
 
 beforeEach(() => {
@@ -68,11 +68,13 @@ describe('DateRange', () => {
   });
 
   test('calculate new selection by retaining the unset end date, based on retainEndDateOnFirstSelection prop', () => {
-    testRenderer.update(<DateRange
-      {...commonProps}
-      ranges={[{ ...commonProps.ranges[0], endDate: null }]}
-      retainEndDateOnFirstSelection
-    />);
+    testRenderer.update(
+      <DateRange
+        {...commonProps}
+        ranges={[{ ...commonProps.ranges[0], endDate: null }]}
+        retainEndDateOnFirstSelection
+      />
+    );
     const methodResult = instance.calcNewSelection(subDays(endDate, 10), true);
     compareRanges(methodResult.range, {
       startDate: subDays(endDate, 10),


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
- [x] Modify new range selection behavior when the start date has changed
- [x] Add some tests for various cases related to `calcNewSelection` method of `DateRange` component

------- 
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
The user might want to move the start date without moving the end date, but the component is currently resetting the end date in all start date changes, which is not the ideal behavior in my opinion. See below a few gifs explaining the issue below:

How Google Analytics date selection behaves, (keeps end date selection):
![date-range-behavior-ga-1](https://user-images.githubusercontent.com/770231/121813218-c0a0c880-cc73-11eb-8582-9cfb575f40f2.gif)
![date-range-behavior-ga-2](https://user-images.githubusercontent.com/770231/121813261-052c6400-cc74-11eb-9832-8a995ea44b64.gif)

How the current component behaves when the start date is changed:
![date-range-behavior-rdr-1](https://user-images.githubusercontent.com/770231/121813278-14131680-cc74-11eb-8853-5a5c5d1e4347.gif)

After this PR:
![date-range-behavior-rdr-pr](https://user-images.githubusercontent.com/770231/121813650-a536bd00-cc75-11eb-87bc-720263ca4588.gif)

We might want to bump at least minor version as this changes the behavior, in order to improve functionality.

> Related Issue: https://github.com/hypeserver/react-date-range/issues/464