### PR TITLE
Fix set focusedRange to end date does not seems to make effect

### DIFF
--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -122,7 +122,10 @@ class Calendar extends PureComponent {
       date: 'date',
     };
     const targetProp = propMapper[this.props.displayMode];
-    if (this.props[targetProp] !== prevProps[targetProp]) {
+    if (
+      this.props[targetProp] !== prevProps[targetProp] ||
+      this.props.focusedRange != prevProps.focusedRange
+    ) {
       this.updateShownDate(this.props);
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,12 @@ export function calcFocusDate(currentFocusedDate, props) {
   }
   targetInterval.start = startOfMonth(targetInterval.start || new Date());
   targetInterval.end = endOfMonth(targetInterval.end || targetInterval.start);
-  const targetDate = targetInterval.start || targetInterval.end || shownDate || new Date();
+  const targetDate =
+    (focusedRange[1]
+      ? targetInterval.end || targetInterval.start
+      : targetInterval.start || targetInterval.end) ||
+    shownDate ||
+    new Date();
 
   // initial focus
   if (!currentFocusedDate) return shownDate || targetDate;

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,35 @@
+import { endOfMonth, startOfMonth } from 'date-fns';
+import { calcFocusDate } from './utils';
+
+describe('calcFocusDate', () => {
+  const ranges = [
+    {
+      startDate: new Date(2021, 0, 10),
+      endDate: new Date(2022, 10, 20),
+    },
+  ];
+
+  describe('when focusedRange[1] equals 0', () => {
+    test('should return startDate', () => {
+      expect(
+        calcFocusDate(new Date(), {
+          ranges,
+          focusedRange: [0, 0],
+          displayMode: 'dateRange',
+        })
+      ).toEqual(startOfMonth(ranges[0].startDate));
+    });
+  });
+
+  describe('when focusedRange[1] equals 1', () => {
+    test('should return endDate', () => {
+      expect(
+        calcFocusDate(new Date(), {
+          ranges,
+          focusedRange: [0, 1],
+          displayMode: 'dateRange',
+        })
+      ).toEqual(endOfMonth(ranges[0].endDate));
+    });
+  });
+});


### PR DESCRIPTION
## Types of changes

This PR fixes the bug when setting the focusedRange={[0, 1]} does not show the end date of the range.

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description

This PR basically changes this line https://github.com/hypeserver/react-date-range/blob/90c59accb6fcc3a0f34a2c57e318359aeb33ba01/src/utils.js#L30 to take into account the `rangeElement` param of `focusedRange` to set the **shownDate**.

> Related Issue: fixes #506 