### PR TITLE
Add possibility to prevent month focusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ showPreview(DateRange)               | bool      | true             | visibility
 editableDateInputs(Calendar)         | bool      | false            | whether dates can be edited in the Calendar's input fields
 dragSelectionEnabled(Calendar)       | bool      | true             | whether dates can be selected via drag n drop
 calendarFocus(Calendar)              | String    | 'forwards'       | Whether calendar focus month should be forward-driven or backwards-driven. can be 'forwards' or 'backwards'
-preventSnapRefocus(Calendar)  | bool      | false            | prevents unneceessary refocus of shown range on selection
+preventSnapRefocus(Calendar)         | bool      | false            | prevents unneceessary refocus of shown range on selection
+preventFocusOnDateChange(Calendar)   | bool      | false            | prevents any focus except the initial
 onPreviewChange(DateRange)           | Object    |                  | Callback function for preview changes
 dateDisplayFormat                    | String    | `MMM d, yyyy`    | selected range preview formatter. Check out [date-fns's format option](https://date-fns.org/docs/format)
 dayDisplayFormat                     | String    | `d`              | selected range preview formatter. Check out [date-fns's format option](https://date-fns.org/docs/format)

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -558,6 +558,7 @@ Calendar.defaultProps = {
   fixedHeight: false,
   calendarFocus: 'forwards',
   preventSnapRefocus: false,
+  preventFocusOnDateChange: false,
   ariaLabels: {},
 };
 
@@ -614,6 +615,7 @@ Calendar.propTypes = {
   fixedHeight: PropTypes.bool,
   calendarFocus: PropTypes.string,
   preventSnapRefocus: PropTypes.bool,
+  preventFocusOnDateChange: PropTypes.bool,
   ariaLabels: ariaLabelsShape,
 };
 

--- a/src/components/DateRangePicker/README.md
+++ b/src/components/DateRangePicker/README.md
@@ -50,6 +50,32 @@ const [state, setState] = useState([
 />;
 ```
 
+#### Example: Backwards 2 Month View with preventFocusOnDateChange
+
+```jsx inside Markdown
+import { addDays } from 'date-fns';
+import { useState } from 'react';
+
+const [state, setState] = useState([
+  {
+    startDate: new Date(),
+    endDate: addDays(new Date(), 7),
+    key: 'selection'
+  }
+]);
+
+<DateRangePicker
+  onChange={item => setState([item.selection])}
+  showSelectionPreview={true}
+  moveRangeOnFirstSelection={false}
+  months={2}
+  ranges={state}
+  direction="horizontal"
+  preventFocusOnDateChange={true}
+  calendarFocus="backwards"
+/>;
+```
+
 #### Example: Vertical Infinite
 
 ```jsx inside Markdown

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,15 @@ import {
 } from 'date-fns';
 
 export function calcFocusDate(currentFocusedDate, props) {
-  const { shownDate, date, months, ranges, focusedRange, displayMode } = props;
+  const {
+    shownDate,
+    date,
+    months,
+    ranges,
+    focusedRange,
+    displayMode,
+    preventFocusOnDateChange,
+  } = props;
   // find primary date according the props
   let targetInterval;
   if (displayMode === 'dateRange') {
@@ -34,6 +42,10 @@ export function calcFocusDate(currentFocusedDate, props) {
 
   // // just return targetDate for native scrolled calendars
   // if (props.scroll.enabled) return targetDate;
+  if (preventFocusOnDateChange) {
+    return currentFocusedDate;
+  }
+
   if (differenceInCalendarMonths(targetInterval.start, targetInterval.end) > months) {
     // don't change focused if new selection in view area
     return currentFocusedDate;


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description

Added additional Calendar `preventFocusOnDateChange` prop to prevent any month jumping completely.

> Related Issue: #515