### PR TITLE
feature/touchscreen-friendly

### DIFF
--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -335,6 +335,7 @@ class Calendar extends PureComponent {
     );
   };
   onDragSelectionStart = date => {
+    console.log(`onDragSelectionStart: ${date}`);
     const { onChange, dragSelectionEnabled } = this.props;
 
     if (dragSelectionEnabled) {
@@ -351,6 +352,7 @@ class Calendar extends PureComponent {
   };
 
   onDragSelectionEnd = date => {
+    console.log(`onDragSelectionEnd: ${date}`);
     const { updateRange, displayMode, onChange, dragSelectionEnabled } = this.props;
 
     if (!dragSelectionEnabled) return;
@@ -372,6 +374,7 @@ class Calendar extends PureComponent {
     }
   };
   onDragSelectionMove = date => {
+    console.log(`onDragSelectionMove: ${date}`);
     const { drag } = this.state;
     if (!drag.status || !this.props.dragSelectionEnabled) return;
     this.setState({
@@ -493,7 +496,7 @@ class Calendar extends PureComponent {
               isVertical ? this.styles.monthsVertical : this.styles.monthsHorizontal
             )}>
             {new Array(this.props.months).fill(null).map((_, i) => {
-              let monthStep = addMonths(this.state.focusedDate, i);;
+              let monthStep = addMonths(this.state.focusedDate, i);
               if (this.props.calendarFocus === 'backwards') {
                 monthStep = subMonths(this.state.focusedDate, this.props.months - 1 - i);
               }

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -427,6 +427,7 @@ class Calendar extends PureComponent {
       <div
         className={classnames(this.styles.calendarWrapper, className)}
         onMouseUp={() => this.setState({ drag: { status: false, range: {} } })}
+        onTouchEnd={() => this.setState({ drag: { status: false, range: {} } })}
         onMouseLeave={() => {
           this.setState({ drag: { status: false, range: {} } });
         }}>

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -335,7 +335,6 @@ class Calendar extends PureComponent {
     );
   };
   onDragSelectionStart = date => {
-    console.log(`onDragSelectionStart: ${date}`);
     const { onChange, dragSelectionEnabled } = this.props;
 
     if (dragSelectionEnabled) {
@@ -352,7 +351,6 @@ class Calendar extends PureComponent {
   };
 
   onDragSelectionEnd = date => {
-    console.log(`onDragSelectionEnd: ${date}`);
     const { updateRange, displayMode, onChange, dragSelectionEnabled } = this.props;
 
     if (!dragSelectionEnabled) return;
@@ -374,7 +372,6 @@ class Calendar extends PureComponent {
     }
   };
   onDragSelectionMove = date => {
-    console.log(`onDragSelectionMove: ${date}`);
     const { drag } = this.state;
     if (!drag.status || !this.props.dragSelectionEnabled) return;
     this.setState({

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -335,6 +335,7 @@ class Calendar extends PureComponent {
     );
   };
   onDragSelectionStart = date => {
+    console.log(`onDragSelectionStart: ${date}`);
     const { onChange, dragSelectionEnabled } = this.props;
 
     if (dragSelectionEnabled) {
@@ -351,6 +352,7 @@ class Calendar extends PureComponent {
   };
 
   onDragSelectionEnd = date => {
+    console.log(`onDragSelectionEnd: ${date}`);
     const { updateRange, displayMode, onChange, dragSelectionEnabled } = this.props;
 
     if (!dragSelectionEnabled) return;
@@ -372,6 +374,7 @@ class Calendar extends PureComponent {
     }
   };
   onDragSelectionMove = date => {
+    console.log(`onDragSelectionMove: ${date}`);
     const { drag } = this.state;
     if (!drag.status || !this.props.dragSelectionEnabled) return;
     this.setState({

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -17,6 +17,8 @@ class DateRange extends Component {
     this.styles = generateStyles([coreStyles, props.classNames]);
   }
   calcNewSelection = (value, isSingleValue = true) => {
+    console.log(`calcNewSelection: ${JSON.stringify(value)}`);
+    console.log(`isSingleValue: ${isSingleValue}`);
     const focusedRange = this.props.focusedRange || this.state.focusedRange;
     const {
       ranges,

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -17,8 +17,6 @@ class DateRange extends Component {
     this.styles = generateStyles([coreStyles, props.classNames]);
   }
   calcNewSelection = (value, isSingleValue = true) => {
-    console.log(`calcNewSelection: ${JSON.stringify(value)}`);
-    console.log(`isSingleValue: ${isSingleValue}`);
     const focusedRange = this.props.focusedRange || this.state.focusedRange;
     const {
       ranges,

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -23,8 +23,11 @@ class DayCell extends Component {
     }
   };
 
+  findButtonElem(elems) {
+    return elems.find(elem => elem.nodeName === 'BUTTON');
+  }
+
   handleTouchEvent = event => {
-    console.log('handleTouchEvent: ', event.type);
     const { day, disabled, onMouseDown, onMouseUp, onMouseEnter, onPreviewChange } = this.props;
     const stateChanges = {};
     if (disabled) {
@@ -33,9 +36,10 @@ class DayCell extends Component {
     }
 
     const isNewDay = targetElements => {
-      if (targetElements && targetElements[2].className === 'rdrDay') {
-        const newDay = targetElements[2].getAttribute('data-day');
-        if (newDay !== this.state.touchOverDay) {
+      const buttonElem = this.findButtonElem(targetElements);
+      if (targetElements && buttonElem && buttonElem.classList.contains('rdrDay')) {
+        const newDay = buttonElem.getAttribute('data-day');
+        if (newDay && newDay !== this.state.touchOverDay) {
           return newDay;
         }
       }
@@ -49,9 +53,9 @@ class DayCell extends Component {
             event.touches[0].clientX,
             event.touches[0].clientY
           );
+          if (targetElements.length === 0) return;
           const newDay = isNewDay(targetElements);
           if (newDay) {
-            console.log('New day: ', newDay);
             onMouseEnter(new Date(newDay));
             onPreviewChange(new Date(newDay));
             this.setState({ touchOverDay: newDay });
@@ -59,8 +63,11 @@ class DayCell extends Component {
         }
         break;
       case 'touchend':
-        onMouseUp(new Date(this.state.touchOverDay));
-        this.setState({ touchOverDay: null });
+        {
+          const endDate = new Date(this.state.touchOverDay);
+          onMouseUp(endDate);
+          this.setState({ touchOverDay: null });
+        }
         break;
       case 'touchstart':
         stateChanges.active = true;
@@ -68,9 +75,7 @@ class DayCell extends Component {
         break;
     }
   };
-
   handleMouseEvent = event => {
-    console.log('handleMouseEvent: ', event.type);
     const { day, disabled, onPreviewChange, onMouseEnter, onMouseDown, onMouseUp } = this.props;
     const stateChanges = {};
     if (disabled) {

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -71,7 +71,6 @@ class DayCell extends Component {
 
     switch (event.type) {
       case 'mouseenter':
-      case 'mouseover':
         onMouseEnter(day);
         onPreviewChange(day);
         stateChanges.hover = true;
@@ -198,7 +197,6 @@ class DayCell extends Component {
         type="button"
         data-day={this.props.day.toISOString()}
         onMouseEnter={this.handleMouseEvent}
-        onMouseOver={this.handleMouseEvent}
         onMouseLeave={this.handleMouseEvent}
         onTouchStart={this.handleTouchEvent}
         onTouchMove={this.handleTouchEvent}
@@ -215,7 +213,7 @@ class DayCell extends Component {
         style={{ color: this.props.color }}>
         {this.renderSelectionPlaceholders()}
         {this.renderPreviewPlaceholder()}
-        <span aria-label="test" className={this.props.styles.dayNumber}>
+        <span className={this.props.styles.dayNumber}>
           {dayContentRenderer?.(this.props.day) || (
             <span>{format(this.props.day, this.props.dayDisplayFormat)}</span>
           )}

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -34,14 +34,15 @@ class DayCell extends Component {
       ? document.elementsFromPoint(event.touches[0].clientX, event.touches[0].clientY)
       : null;
 
-    // console.log(`targetElements: ${targetElement.length}`);
     switch (event.type) {
       case 'touchmove':
         console.log(`touchmove event on ${day}`);
-        // console.log(`Event: ${JSON.stringify(event)}`);
         if (targetElement && targetElement[2].className === 'rdrDay') {
           if (targetElement[2] !== this.state.targetElement) {
             console.log(`targetElement Day: ${targetElement[0].innerText}`);
+            const targetDayString = targetElement[2].getAttribute('data-day');
+            onMouseEnter(new Date(targetDayString));
+            onPreviewChange(new Date(targetDayString));
             this.setState({ targetElement: targetElement[2] });
           }
         }
@@ -190,6 +191,7 @@ class DayCell extends Component {
     return (
       <button
         type="button"
+        data-day={this.props.day.toISOString()}
         onMouseEnter={this.handleMouseEvent}
         onMouseOver={this.handleMouseEvent}
         onMouseLeave={this.handleMouseEvent}

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -23,10 +23,6 @@ class DayCell extends Component {
     }
   };
 
-  findButtonElem(elems) {
-    return elems.find(elem => elem.nodeName === 'BUTTON');
-  }
-
   handleTouchEvent = event => {
     const { day, disabled, onMouseDown, onMouseUp, onMouseEnter, onPreviewChange } = this.props;
     const stateChanges = {};
@@ -35,8 +31,12 @@ class DayCell extends Component {
       return;
     }
 
+    const findButtonElem = elems => {
+      return elems.find(elem => elem.nodeName === 'BUTTON');
+    };
+
     const isNewDay = targetElements => {
-      const buttonElem = this.findButtonElem(targetElements);
+      const buttonElem = findButtonElem(targetElements);
       if (targetElements && buttonElem && buttonElem.classList.contains('rdrDay')) {
         const newDay = buttonElem.getAttribute('data-day');
         if (newDay && newDay !== this.state.touchOverDay) {

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -41,19 +41,7 @@ class DayCell extends Component {
         // console.log(`Event: ${JSON.stringify(event)}`);
         if (targetElement && targetElement[2].className === 'rdrDay') {
           if (targetElement[2] !== this.state.targetElement) {
-            console.log(`New targetElement, dispatching mouseenter: ${targetElement[2].day}`);
             console.log(`targetElement Day: ${targetElement[0].innerText}`);
-            const enterEvent = new MouseEvent('mouseover');
-            const focusEvent = new FocusEvent('focus');
-
-            targetElement[2].dispatchEvent(enterEvent);
-            targetElement[2].dispatchEvent(focusEvent);
-
-            const leaveEvent = new MouseEvent('mouseleave');
-            if (this.state.targetElement) {
-              console.log(`dispatching mouseleave: ${this.state.targetElement}`);
-              this.state.targetElement.dispatchEvent(leaveEvent);
-            }
             this.setState({ targetElement: targetElement[2] });
           }
         }

--- a/src/components/DayCell/index.js
+++ b/src/components/DayCell/index.js
@@ -11,7 +11,7 @@ class DayCell extends Component {
     this.state = {
       hover: false,
       active: false,
-      touchOverDay: null,
+      touchOverDay: props.day.toISOString(),
     };
   }
 
@@ -24,6 +24,7 @@ class DayCell extends Component {
   };
 
   handleTouchEvent = event => {
+    console.log('handleTouchEvent: ', event.type);
     const { day, disabled, onMouseDown, onMouseUp, onMouseEnter, onPreviewChange } = this.props;
     const stateChanges = {};
     if (disabled) {
@@ -31,28 +32,35 @@ class DayCell extends Component {
       return;
     }
 
+    const isNewDay = targetElements => {
+      if (targetElements && targetElements[2].className === 'rdrDay') {
+        const newDay = targetElements[2].getAttribute('data-day');
+        if (newDay !== this.state.touchOverDay) {
+          return newDay;
+        }
+      }
+      return null;
+    };
+
     switch (event.type) {
       case 'touchmove':
         {
-          const targetElement = document.elementsFromPoint(
+          const targetElements = document.elementsFromPoint(
             event.touches[0].clientX,
             event.touches[0].clientY
           );
-          if (targetElement && targetElement[2].className === 'rdrDay') {
-            const newDay = targetElement[2].getAttribute('data-day');
-            if (newDay !== this.state.touchOverDay) {
-              onMouseEnter(new Date(newDay));
-              onPreviewChange(new Date(newDay));
-              this.setState({ touchOverDay: newDay });
-            }
+          const newDay = isNewDay(targetElements);
+          if (newDay) {
+            console.log('New day: ', newDay);
+            onMouseEnter(new Date(newDay));
+            onPreviewChange(new Date(newDay));
+            this.setState({ touchOverDay: newDay });
           }
         }
         break;
       case 'touchend':
-        {
-          onMouseUp(new Date(this.state.touchOverDay));
-          this.setState({ touchOverDay: null });
-        }
+        onMouseUp(new Date(this.state.touchOverDay));
+        this.setState({ touchOverDay: null });
         break;
       case 'touchstart':
         stateChanges.active = true;
@@ -62,6 +70,7 @@ class DayCell extends Component {
   };
 
   handleMouseEvent = event => {
+    console.log('handleMouseEvent: ', event.type);
     const { day, disabled, onPreviewChange, onMouseEnter, onMouseDown, onMouseUp } = this.props;
     const stateChanges = {};
     if (disabled) {


### PR DESCRIPTION
## Types of changes

I've added touch event handlers to the DayCell component to make date range selection more user friendly on touchscreen devices. 

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
Previously, when using a touchscreen device it was difficult to select a range of dates. It was necessary to open the DateRangePicker tap the start date of the desired range (which would then close the picker), then reopen the DateRangePicker, tap the end date input box at the top, then tap the desired end date to select the range.

With this enhancement, you open the DateRangePicker, begin by touching and holding your finger on the desired start date (or simply tap for a single day, rather than a range). Next, to select a range, swipe/drag to the desired end date. When you lift your finger to end the touch interaction, the selected date range is set. 

You can easily see the selected dates change as you interact with the calendar as the selection is highlighted just as it is when using a mouse. 

## Methodology
To accomplish this enhancement, I am using document.elementsFromPoint with coordinates from the touchmove events to emulate the mouseenter behavior. Unlike mouse events, touch events do not retarget as the touch point is moved over different elements, it stays anchored to the element at the first touch point (the start day of the range being selected). Because of this, as the touch is moved and when the touch ends, it is the start day that is the target of the fired events and that will call the onDragSelection... functions (using the mouse... aliases from the props). So, I needed a way for the first selected day to be aware of the date that the touch was currently over and where it ended. I thought about making changes in a parent component that had access to all the child DayCells, but instead decided to add a data-day attribute to each DayCell button which the starting day (sibling element) could access. This seemed to be more consistent with the existing mouse handling and involve fewer code changes. 


## Review
I have done local testing using Chrome developer tools using device emulation. I've also run `yarn run lint` and `yarn run test` and did not get any issues or errors related to this code (there were some warnings about babylon being deprecated, no license field in package.json, and updating caniuse-lite, but these were not part of the work in this branch and all tests passed).

Still, any review and feedback on this work is welcome and appreciated! 

Thanks!

> Related Issue: #578 