### PR TITLE
shownDate changes do not change Calendar #552

### DIFF
--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -103,8 +103,8 @@ class Calendar extends PureComponent {
           months: this.list.getVisibleRange().length,
         }
       : props;
-    const newFocus = calcFocusDate(this.state.focusedDate, newProps);
-    this.focusToDate(newFocus, newProps);
+        const newFocus = calcFocusDate(this.state.focusedDate, newProps);
+        this.focusToDate(newFocus, newProps);    
   };
   updatePreview = val => {
     if (!val) {
@@ -122,6 +122,9 @@ class Calendar extends PureComponent {
     if (this.props.scroll.enabled) {
       // prevent react-list's initial render focus problem
       setTimeout(() => this.focusToDate(this.state.focusedDate));
+    }
+    if (this.props.setShownDate) {
+      this.props.setShownDate(this.handleChangeShowDateFromParent)
     }
   }
 
@@ -152,6 +155,10 @@ class Calendar extends PureComponent {
     }
   }
 
+  // value => Date object
+  handleChangeShowDateFromParent = (value) => {
+    this.changeShownDate(value)
+  }
   changeShownDate = (value, mode = 'set') => {
     const { focusedDate } = this.state;
     const { onShownDateChange, minDate, maxDate } = this.props;
@@ -576,6 +583,7 @@ Calendar.propTypes = {
   locale: PropTypes.object,
   shownDate: PropTypes.object,
   onShownDateChange: PropTypes.func,
+  setShownDate: PropTypes.func,
   ranges: PropTypes.arrayOf(rangeShape),
   preview: PropTypes.shape({
     startDate: PropTypes.object,


### PR DESCRIPTION
## Problem Statement
We need a way to manually change the shown date to a specific month because it is not always relevant to automatically navigate to the selected start date itself. Currently, this package offers an attribute named shownDate which does not respond desirably. 

## Faced Problem Scenario 
This problem was faced by me while I was implementing a date range picker with this package. The purpose of that picker is to let users pick vacation ranges from the calendar. However, I had to check existing leaves and vacations while changing each month which updates a state by calling an API. That API update is re-rendering the selected date and the navigation is coming back to that selected date. 

## Solution of this Pull Request
In this PR, I have added another attribute named setShownDate which will return a callback function to navigate to a specific month. The callback function will take one date parameter. It will simply move the view to that specific date.

## How to use
```js
const [changeShownDate, setChangeShownDate] = useState(null)
```
```html
<DateRange 
{...props}
setShownDate={func => setChangeShownDate(func)}
/>

<button onClick={() => setChangeShownDate(changeShownDate(new Date('01/25/2015')))}>
```

After calling the function from state, the calendar will navigate to the specific date.
